### PR TITLE
(potential) fix: 9070/9070XT amdgpu drivers not present in previous kernel-firmware

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -3,5 +3,5 @@ sources:
   linux-ubuntu-14-04-2.tar.xz: 6d984ef753e72dd4cd5fa85df59abe3b6a7270fe
   firmware_1900.fw: 11943054eef46dec081acff5f11b7c557fdea050
   linux-firmware-pine64-20240313.tar.zst: 1791da6f284aa5396ec6d75552cde05a91ed575e
-  linux-firmware-20250306.tar.zst: 40275d7e4bb014c8163192308c0cef2463ce03dc
-  dvb-firmware-20250306.tar.gz: 62a371d0f5ec5c24240f1aa01ea881550a8ed0ac
+  linux-firmware-20250314.tar.zst: 
+  dvb-firmware-20250314.tar.gz: 

--- a/kernel-firmware.spec
+++ b/kernel-firmware.spec
@@ -9,7 +9,7 @@
 
 Summary:	Linux kernel firmware files
 Name:		kernel-firmware
-Version:	20250306
+Version:	20250314
 Release:	1
 License:	GPLv2
 Group:		System/Kernel and hardware


### PR DESCRIPTION
Hello,
Sorry if this is one of those drive-by PRs with two meaningless commits, but a user has been having problems with his 9070 XT on openmandriva and I linked it from previous experience with missing/seriously misbehaving amdgpu kernel modules (the ones for these two gpus specifically). Here is the issue: https://forum.openmandriva.org/t/openmandriva-fails-to-boot-while-new-gpu-amd-9070xt-is-plugged-in/6794/16
I am NOT fully sure this will fix it (don't have the card till next month), but as the latest release of kernel-firmware is from the 06/03/25 which is the launch day of the 9070 and on the 11th a lot of amdgpu-related patches landed upstream (see https://web.git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/), I think there is a high probability that the missing driver was added or that something was corrected in these patches that will make the 9070/XT work (or at least initialize past grub for further debugging). I don't have one on hand right now, but I'll hopefully have one next month (if my preorder is fulfilled).
As kernel-firmware is pulled from git I just changed the build number to today to launch a new build and everything should be fine. Alternatively, they dropped a new version after the amdgpu patches so we can also build from the 110325 tag on upstream. I left the sha1sums empty to be filled once the abf build is done.
Thanks!